### PR TITLE
RVM: Update key server URL

### DIFF
--- a/macOS_post-install.md
+++ b/macOS_post-install.md
@@ -50,7 +50,7 @@ brew install nvm
 mkdir ~/.nvm
 
 # Ruby - RVM
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 \curl -sSL https://get.rvm.io | bash -s stable --ruby
 
 # Python - PyEnv


### PR DESCRIPTION
Current key server URL fails :
```
$ gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB

gpg: keyserver receive failed: No route to host
```

Changing it to the one from [https://rvm.io/rvm/security](https://rvm.io/rvm/security) solved the problem.